### PR TITLE
chore: updated documentation and Read me

### DIFF
--- a/.storybook/denali-storybook-theme.js
+++ b/.storybook/denali-storybook-theme.js
@@ -37,7 +37,7 @@ export default create({
     inputTextColor: 'black',
     inputBorderRadius: 4,
 
-    brandTitle: 'Link to the Denali',
-    brandUrl: 'https://denali.design',
+    brandTitle: 'Link to the Denali Github',
+    brandUrl: 'https://github.com/denali-design/denali-react',
     brandImage: denaliReactLogo,
 });

--- a/README.md
+++ b/README.md
@@ -57,9 +57,24 @@ Learn more about the browsers and devices we support [here](https://denali.desig
 -   **IE11+** on Windows
 -   **Edge** on Windows
 
+## Versioning
+
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the tags on this [repository](https://github.com/denali-design/denali-react).
+
+## Maintainers
+
+-   [**Chas Turansky**](https://github.com/chasturansky)
+-   [**Shadi Abu Hilal**](https://github.com/shadiabuhilal)
+-   [**Jon Kilroy**](https://github.com/jkusa)
+-   [**Anusha Ganti**](https://github.com/anusha-66)
+
 ## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
 [status-image]: https://cd.screwdriver.cd/pipelines/7272/badge
 [status-url]: https://cd.screwdriver.cd/pipelines/7272
+
+## License
+
+Code licensed under the MIT license. See [LICENSE file](LICENESE.md) for terms.

--- a/documentation/installation.stories.mdx
+++ b/documentation/installation.stories.mdx
@@ -40,7 +40,7 @@ To get started quickly just import a two `.css` files from [jsDelivr](https://ww
 
 ### Denali
 
-This CDN link includes everything you see documented in Denali CSS components, layouts, resets, and helpers. Please note this CDN link does not include the [Denali Icon Font](https://github.com/denali-design/denali-icon-font) library.
+This CDN link includes everything you see documented in Denali CSS components, layouts, resets, and helpers. Please note this CDN link does not include the [Denali Icon Font](https://github.com/denali-design/denali-icons) library.
 
 ```
 https://cdn.jsdelivr.net/npm/denali-css/css/denali.css
@@ -63,11 +63,25 @@ Add these link tags into the head of your HTML document for easy Installation.
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/denali-css/css/denali.css">
 ```
 
+### Using Denali Icons & Fonts via NPM
+
+### Install
+
+```
+npm install @denali-design/icons
+```
+
+### Import
+
+After installation, you can import the CSS file into your js project using the code below.
+
+```
+import '@denali-design/icons/dist/font/denali-icons-font.css';
+```
+
 ---
 
-### via NPM
-
-## Using Denali via NPM
+### Using Denali CSS via NPM
 
 For most projects we recommend installing Denali via node package manager which will expose the `.scss` files. These give you the flexibility of building your application the way you see fit and utilize all Denali has to offer.
 
@@ -102,7 +116,7 @@ If you want to get started right away install denali dependencies (Denali-React,
 ```js
 import { DnButton } from '@denali-design/react'; //INFO: To load Denali-React component library
 import 'denali-css/css/denali.css'; // INFO: To load denali css
-import 'denali-icon-font/dist/denali-icon-font.css'; // INFO: To load denali icon font css
+import '@denali-design/icons/dist/font/denali-icons-font.css'; // INFO: To load denali icon font css
 import './css/site-denali-theme.css'; // INFO: To load denali them css
 
 function App() {


### PR DESCRIPTION
Before: Links on documentation and import statements for Icons library were pointing to deprecated folder
             ReadMe was not consistent with Denali Site and Denali CSS repos
             Denali React Storybook was pointing to Denali.design, instead of Denali React github
             
After: Updated documentation with correct links, Updated Read Me, Updated logo URL to point to github URL 
